### PR TITLE
set logo dynamically from dashboard env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,12 @@
 .DS_Store
 node_modules
 dist
+compose.yaml
+Dockerfile
+Dockerfile.test
+.env
+.dockerignore
+.gitignore
+CHANGELOG.md
+README.md
+.vscode

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,6 @@
+FROM node:lts-alpine AS build
+WORKDIR /app
+COPY . .
+RUN npm install
+EXPOSE 8080
+CMD ["npm", "run", "dev-local"]

--- a/README.md
+++ b/README.md
@@ -58,5 +58,15 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
 
+## Change logo
+
+You can change the logo two ways:
+
+1. Check out this repository, and change the logo image in Layout.astro. If you are using the claim page as a Docker image, you'll have to then build a new image. If you are running this in a Docker compose, you'll have to make sure the compose points at your image in either your local docker cache or in Docker Hub if you've published the image there. Or you can set the Docker compose to use your checked out copy as the build context.
+
+2. Set the url for your logo as an env in the [dcc-admin-dashboard](https://github.com/digitalcredentials/dcc-admin-dashboard). You can also set the width and height. Read about how to do that in the [dcc-admin-dashboard README](https://github.com/digitalcredentials/dcc-admin-dashboard/blob/main/README.md#claim-page-logo/).
+
+The advantage to the second approach is that you avoid having to maintain your own copy of the claim page code - which carries the consequent hassle of having to update your code to stay current with any changes that might be made to the DCC version of the claim page code.
+
 ## License
 MIT © [MIT](#)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "dev-local": "astro dev --port 8080"
+    "dev-local": "astro dev --host --port 8080"
   },
   "dependencies": {
     "@astrojs/tailwind": "^5.0.0",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,6 +8,7 @@ interface Props {
 }
 
 const { title } = Astro.props;
+
 ---
 
 <!doctype html>
@@ -23,7 +24,8 @@ const { title } = Astro.props;
     </head>
     <body>
         <main class="w-full h-full flex flex-col gap-10 xl:gap-20 p-5 xl:p-24 bg-slate-50">
-            <Image class="h-24 w-96" src={Logo} alt="Digital Credentials Consortium" />
+        <Image id="logo" alt="Digital Credentials Consortium" src={Logo}/>
+    
             <slot />
         </main>
         <style is:global>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import Modal from '../components/Modal.astro';
 
 import Placeholder from '../assets/images/placeholder.png';
 import Button from '../components/Button.astro';
+import Logo from '../assets/images/logo.png';
 ---
 
 <Layout title="Getting Credential...">
@@ -38,12 +39,32 @@ import Button from '../components/Button.astro';
     const info1 = document.getElementById('info-1') as HTMLParagraphElement;
     const info2 = document.getElementById('info-2') as HTMLParagraphElement;
     const qrcode = document.getElementById('qr-code') as HTMLImageElement;
+    const logo = document.getElementById('logo') as HTMLImageElement;
     const directAnchorLink = document.getElementById('link-direct') as HTMLAnchorElement;
     
     title.innerText = 'Getting Credential...';
 
     try {
     
+        const logoResponse = await fetch(`${payloadUrl}/claim-config`);
+        
+        if (logoResponse.status === 200) {
+  
+            const {logoURL,logoWidth,logoHeight} = (await logoResponse.json()) as {
+                logoURL: string;
+                logoWidth: string;
+                logoHeight: string;
+            }
+            // bust the cache
+            await fetch(logoURL, {cache: 'reload', mode: 'no-cors'})
+            if (logoURL !== 'default') {
+                logo.src = logoURL;
+                logo.height = logoHeight;
+                logo.width = logoWidth;
+                logo.class = '';
+            } 
+        } 
+
         const res = await fetch(`${payloadUrl}/get-credential-links`, {
             headers: { Authorization: `Bearer ${token}` },
         });
@@ -104,6 +125,6 @@ import Button from '../components/Button.astro';
         }
     } catch (error) {
         console.error(error);
-        window.location.href = `${basePath}/error`;
+       window.location.href = `${basePath}/error`;
     }
 </script>


### PR DESCRIPTION
Works together with https://github.com/digitalcredentials/dcc-admin-dashboard/pull/63 to allow setting the claim page logo using an environment variable in the dashboard.

We do it this way so that people can use the prebuilt docker hub image without having to rebuild their own.